### PR TITLE
Update hobbies validation

### DIFF
--- a/validator.js
+++ b/validator.js
@@ -17,7 +17,7 @@ const signupSchema = Joi.object({
     then: Joi.string().required().min(3).max(50),
     otherwise: Joi.string().optional(),
   }),
-  hobbies: Joi.array().items([Joi.string(), Joi.number()]),
+  hobbies: Joi.array().items(Joi.string(), Joi.number()),
   acceptTos: Joi.boolean().truthy("Yes").valid(true).required(),
 });
 


### PR DESCRIPTION
In the hobbies validation, the items() method accepts both strings and numbers without requiring them to be inside an array. If you wrap them inside an array, it will cause an error (crash the app).